### PR TITLE
fix: remove generic parameters in generated getMethod() reflection call

### DIFF
--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/codegeneration/SourceGenerator.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/codegeneration/SourceGenerator.java
@@ -208,8 +208,10 @@ public class SourceGenerator {
 
                 List<String> parametersType = Arrays.stream(method.getGenericParameterTypes())
                         .map(pt -> parseArgumentType(pt, classesToImport)).toList();
+                List<String> nonGenericParametersType = Arrays.stream(method.getParameterTypes())
+                        .map(pt -> parseArgumentType(pt, new HashSet<>())).toList();
 
-                MethodDTO methodDTO = new MethodDTO(returnValue, name, parametersType);
+                MethodDTO methodDTO = new MethodDTO(returnValue, name, parametersType, nonGenericParametersType);
                 logger.trace("Found method '{}' with parameters '{}' and return value '{}'.", name, parametersType,
                         returnValue);
 
@@ -343,7 +345,8 @@ public class SourceGenerator {
         return lastDotIndex == -1 ? Optional.empty() : Optional.of(fullName.substring(lastDotIndex + 1));
     }
 
-    public record MethodDTO(String returnValueType, String name, List<String> parameterTypes) {
+    public record MethodDTO(String returnValueType, String name, List<String> parameterTypes,
+            List<String> nonGenericParameterTypes) {
     }
 
     private interface InternalGenerator {

--- a/bundles/org.openhab.automation.java223/src/main/resources/generated/ThingAction.ftl
+++ b/bundles/org.openhab.automation.java223/src/main/resources/generated/ThingAction.ftl
@@ -42,7 +42,7 @@ public class ${simpleClassName} {
         try {
             Class<?> thingActionClass = thingActions.getClass();
 <#if (method.parameterTypes()?size > 0)>
-            Method method = thingActionClass.getMethod("${method.name()}", <#list method.parameterTypes() as parameter>${parameter}.class<#sep>, </#list>);
+            Method method = thingActionClass.getMethod("${method.name()}", <#list method.nonGenericParameterTypes() as parameter>${parameter}.class<#sep>, </#list>);
             <#if (method.returnValueType() != "void")>
             Object returnValue = </#if>method.invoke(thingActions, <#list 1..method.parameterTypes()?size as i>p${i}<#sep>, </#list>);
 <#else>


### PR DESCRIPTION
Hey Gwendal,

I'm playing around with your interesting java223 automation plugin - very nice!
I've stumbled upon a problem in my installation: I've got a lot of ThingActions which use generic parameters. Your current code creates incorret getMethod() code for these.

For instance, excerpt from the SendMailActions class:
```java
    @SuppressWarnings("unchecked")
    public Boolean sendHtmlMailWithAttachments(String p1, String p2, String p3, List<String> p4) {
        if (thingActions == null) {
            thingActions = scriptThingActions.get(SCOPE, thingUID);
        }
        
        try {
            Class<?> thingActionClass = thingActions.getClass();
            Method method = thingActionClass.getMethod("sendHtmlMailWithAttachments", String.class, String.class, String.class, List<String>.class);
            Object returnValue = method.invoke(thingActions, p1, p2, p3, p4);
            return (Boolean) returnValue;
        } catch (NoSuchMethodException | SecurityException | IllegalAccessException
                | IllegalArgumentException | InvocationTargetException e) {
            throw new Java223Exception("Error running action sendHtmlMailWithAttachments", e);
        }
    }
```

The line 
```java
Method method = thingActionClass.getMethod("sendHtmlMailWithAttachments", String.class, String.class, String.class, List<String>.class);
```
obviously does not compile.

My simple fix adds a non-generic type parameter set to the code generation, which results in the correct line:

```java
Method method = thingActionClass.getMethod("sendHtmlMailWithAttachments", String.class, String.class, String.class, List.class);String.class, List.class);
```

I hope you can use this fix or improve your code on it.
Best regards and keep up the work with the binding!
Rouven