### PR TITLE
Remove explicit calls to super()

### DIFF
--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223CompiledScriptCache.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223CompiledScriptCache.java
@@ -36,7 +36,6 @@ public class Java223CompiledScriptCache {
     private Cache<String, Java223CompiledScript> cache;
 
     public Java223CompiledScriptCache(int cacheSize) {
-        super();
         this.cacheSize = cacheSize;
         cache = Caffeine.newBuilder().maximumSize(cacheSize).build();
     }

--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223ScriptEngine.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223ScriptEngine.java
@@ -68,7 +68,6 @@ public class Java223ScriptEngine extends JavaScriptEngine implements Invocable {
     public Java223ScriptEngine(Java223CompiledScriptCache compiledScriptCache, Java223Strategy java223Strategy,
             PackageResourceListingStrategy osgiPackageResourceListingStrategy,
             ScriptInterceptorStrategy scriptInterceptorStrategy, List<String> compilationOptions) {
-        super();
         this.cache = compiledScriptCache;
         this.java223Strategy = java223Strategy;
         this.osgiPackageResourceListingStrategy = osgiPackageResourceListingStrategy;

--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/codegeneration/DependencyGenerator.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/codegeneration/DependencyGenerator.java
@@ -88,7 +88,6 @@ public class DependencyGenerator {
      */
     public DependencyGenerator(Path libDir, String additionalBundlesConfig, String additionalClassesConfig,
             BundleContext bundleContext) {
-        super();
         this.libDir = libDir;
         this.additionalBundlesConfig = additionalBundlesConfig;
         this.additionalClassesConfig = additionalClassesConfig;

--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/Java223Strategy.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/Java223Strategy.java
@@ -79,7 +79,6 @@ public class Java223Strategy
     private boolean allowInstanceReuseDefaultProperty;
 
     public Java223Strategy(Map<String, Object> additionalBindings, ClassLoader classLoader) {
-        super();
         this.additionalBindings = additionalBindings;
         this.allowInstanceReuseDefaultProperty = false;
         jarFileManagerfactory = new JarFileManagerFactory(LIB_DIR, classLoader);

--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/jarloader/JarFileManager.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/jarloader/JarFileManager.java
@@ -144,7 +144,6 @@ public class JarFileManager<M extends JavaFileManager> extends ForwardingJavaFil
         Path libDirectory;
 
         public JarFileManagerFactory(Path libDirectory, ClassLoader parentClassLoader) {
-            super();
             this.parentClassLoader = parentClassLoader;
             this.libDirectory = libDirectory;
             // temporary/default use of the parent :


### PR DESCRIPTION
The default constructor of the super class is called anyway implicitly, there is no need to call it explicitly:

https://docs.oracle.com/javase/tutorial/java/IandI/super.html

>  If a constructor does not explicitly invoke a superclass constructor, the Java compiler automatically inserts a call to the no-argument constructor of the superclass. 