### PR TITLE
Java223ScriptEngineFactory: activate after RuleManager is available

### DIFF
--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223ScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223ScriptEngineFactory.java
@@ -115,7 +115,7 @@ public class Java223ScriptEngineFactory extends JavaScriptEngineFactory
     public Java223ScriptEngineFactory(BundleContext bundleContext, Map<String, Object> properties,
             @Reference(target = WatchService.CONFIG_WATCHER_FILTER) WatchService watchService,
             @Reference ItemRegistry itemRegistry, @Reference ThingRegistry thingRegistry,
-            @Reference Java223DependencyTracker dependencyTracker) {
+            @Reference RuleManager ruleManager, @Reference Java223DependencyTracker dependencyTracker) {
 
         try {
             Files.createDirectories(LIB_DIR);
@@ -140,7 +140,7 @@ public class Java223ScriptEngineFactory extends JavaScriptEngineFactory
                 false);
 
         osgiPackageResourceListingStrategy = this::listClassResources;
-        java223Strategy = new Java223Strategy(getAdditionalBindings(),
+        java223Strategy = new Java223Strategy(getAdditionalBindings(ruleManager),
                 bundleContext.getBundle().adapt(BundleWiring.class).getClassLoader());
         java223Strategy.setAllowInstanceReuse(allowInstanceReuse);
         scriptWrappingStrategy = new ScriptWrappingStrategy(enableHelper);
@@ -325,27 +325,7 @@ public class Java223ScriptEngineFactory extends JavaScriptEngineFactory
      *
      * @return Additional data to use when binding
      */
-    private Map<String, Object> getAdditionalBindings() {
-        // If the openHAB cache has been cleaned. The service reference to the RuleManager could be null during
-        // initialization. In this case, we loop to wait a little bit and try again.
-        RuleManager ruleManager = null;
-        for (int nbTry = 1; nbTry <= 20; nbTry++) {
-            try {
-                ruleManager = bundleContext.getService(bundleContext.getServiceReference(RuleManager.class));
-                break;
-            } catch (NullPointerException e) {
-                logger.warn(
-                        "Could not retrieve RuleManager service. Cache cleaned ? Will wait a little bit and try again. {}/20",
-                        nbTry);
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException ignored) {
-                }
-            }
-        }
-        if (ruleManager == null) {
-            throw new IllegalStateException("RuleManager is still null. Initialization failed.");
-        }
+    private Map<String, Object> getAdditionalBindings(RuleManager ruleManager) {
         ThingManager thingManager = bundleContext.getService(bundleContext.getServiceReference(ThingManager.class));
         MetadataRegistry metadataRegistry = bundleContext
                 .getService(bundleContext.getServiceReference(MetadataRegistry.class));


### PR DESCRIPTION
I guess this change enforces that Java223 is loaded after RuleManager is available.  It adds in OSGI-INF/org.openhab.automation.java223.internal.Java223ScriptEngineFactory.xml the line
```xml
<reference name="$005" interface="org.openhab.core.automation.RuleManager" parameter="5"/>	
```

It prevents logging an exception in openhab.log after `openhab-cli clean-cache`, as mentioned at https://community.openhab.org/t/java223-scripting-script-with-java-on-openhab-5-0-1-0-6-0-0-0/159853/13.

With this change, I stopped OH, cleaned the cache, started Openhab, there was no exception in openhab.log.  I repeated this once again and observed the same result.