### PR TITLE
Java223ScriptEngineFactory: compiler warning about unused field `bundleContext`

### DIFF
--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223ScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223ScriptEngineFactory.java
@@ -86,7 +86,6 @@ public class Java223ScriptEngineFactory extends JavaScriptEngineFactory
     public static final String HELPER_LIB_JAR = "helper-lib.jar";
 
     private final BundleWiring bundleWiring;
-    private final BundleContext bundleContext;
 
     private final PackageResourceListingStrategy osgiPackageResourceListingStrategy;
     private final Java223Strategy java223Strategy;
@@ -126,7 +125,6 @@ public class Java223ScriptEngineFactory extends JavaScriptEngineFactory
         }
 
         this.watchService = watchService;
-        this.bundleContext = bundleContext;
         this.bundleWiring = bundleContext.getBundle().adapt(BundleWiring.class);
         this.dependencyTracker = dependencyTracker;
 


### PR DESCRIPTION
This removes a compiler warning:

> [INFO] --- compiler:3.13.0:compile (default-compile) @ org.openhab.automation.java223 --- 
> [INFO] Recompiling the module because of changed source code.
> [WARNING] …/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223ScriptEngineFactory.java:[89,33] The value of the field org.openhab.automation.java223.internal.Java223ScriptEngineFactory.bundleContext is not used