### PR TITLE
obermuhlner/MemoryClassLoader: remove deprecation warning about URL constructor

### DIFF
--- a/bundles/org.openhab.automation.java223/src/3rdparty/java/ch/obermuhlner/scriptengine/java/MemoryClassLoader.java
+++ b/bundles/org.openhab.automation.java223/src/3rdparty/java/ch/obermuhlner/scriptengine/java/MemoryClassLoader.java
@@ -40,10 +40,10 @@ public class MemoryClassLoader extends ClassLoader {
         this.mapClassBytes = mapClassBytes;
 
         try {
-            URL url = new URL(MEMORY_CLASS_URL);
+            URL url = new java.net.URI(MEMORY_CLASS_URL).toURL();
             CodeSource codeSource = new CodeSource(url, (Certificate[]) null);
             protectionDomain = new ProtectionDomain(codeSource, null, this, new Principal[0]);
-        } catch (MalformedURLException e) {
+        } catch (MalformedURLException | java.net.URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
> [WARNING] …/bundles/org.openhab.automation.java223/src/3rdparty/java/ch/obermuhlner/scriptengine/java/MemoryClassLoader.java:[43,27] The constructor java.net.URL(java.lang.String) is deprecated since version 20                                                                                                         

This is the same as https://github.com/eobermuhlner/java-scriptengine/pull/20.