### PR TITLE
Exclude directories freemarker/ext/{rhino,ant} from the bundle

### DIFF
--- a/bundles/org.openhab.automation.java223/pom.xml
+++ b/bundles/org.openhab.automation.java223/pom.xml
@@ -73,6 +73,8 @@
             <phase>package</phase>
             <configuration>
               <excludes>
+                <exclude>freemarker/ext/ant/**</exclude>
+                <exclude>freemarker/ext/rhino/**</exclude>
                 <exclude>helper/**</exclude>
               </excludes>
             </configuration>


### PR DESCRIPTION
This change makes the final jar file smaller.