### PR TITLE
pom.xml: change the scope of org.freemarker from `compile` to `runtime`

### DIFF
--- a/bundles/org.openhab.automation.java223/pom.xml
+++ b/bundles/org.openhab.automation.java223/pom.xml
@@ -19,7 +19,7 @@
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
       <version>2.3.32</version>
-      <scope>compile</scope>
+      <scope>runtime</scope>
     </dependency>
     <!-- jdt annotation classes are included because we want to be able to
       export them to the dependencies jar -->


### PR DESCRIPTION
This does not change the produced org.openhab.automation.java223-5.0.1.jar file.
