### PR TITLE
In transformations `input` is `String` and not `Object`

### DIFF
--- a/bundles/org.openhab.automation.java223/README.md
+++ b/bundles/org.openhab.automation.java223/README.md
@@ -323,13 +323,13 @@ You can return a value. The line returning the value MUST begin with `return `, 
 You can use a Java223 script in transformations.
 A transformation is a piece of code with an input and an output. To do so, you only have to respect this contract:
 
-- you use the openHAB input value named 'input'. It is declared as an `Object`.
+- you use the openHAB input value named 'input'. It is declared as a `String`.
 - your runnable method must return a value
 
 Example of transformation appending the word "Hello" to the input, using the "no boilerplate" functionality:
 
 ```java
-return "Hello " + input.toString();
+return "Hello " + input;
 ```
 
 # Use your IDE

--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/ScriptWrappingStrategy.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/ScriptWrappingStrategy.java
@@ -116,7 +116,7 @@ public class ScriptWrappingStrategy implements ScriptInterceptorStrategy {
             protected @InjectBinding(preset = "cache", named = "sharedCache") ValueCache sharedCache;
             protected @InjectBinding(preset = "cache", named = "privateCache") ValueCache privateCache;
 
-            protected Object input;
+            protected String input;
 
             protected @InjectBinding RuleManager ruleManager;
             protected @InjectBinding ThingManager thingManager;

--- a/bundles/org.openhab.automation.java223/src/main/resources/generated/Java223Script.ftl
+++ b/bundles/org.openhab.automation.java223/src/main/resources/generated/Java223Script.ftl
@@ -65,7 +65,7 @@ public abstract class Java223Script {
     protected @InjectBinding(preset = "cache", named = "privateCache") ValueCache privateCache;
 
     // for transformation support
-    protected @Nullable Object input;
+    protected @Nullable String input;
 
     // additional useful classes:
     protected @InjectBinding RuleManager ruleManager;


### PR DESCRIPTION
This is stated at https://www.openhab.org/docs/configuration/transformations.html#script-transformation “The input value is injected into the script context as a *string* variable `input`.”
    
In [org.openhab.core.automation.module.script.ScriptTransformationService:transform()](https://github.com/openhab/openhab-core/blob/a6a9a076912ec0d777b9f29ab8064e48cc7650b4/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java#L188) the type of `source` is also String, not Object.
    
This allows writing the [following transformation](https://community.openhab.org/t/java223-scripting-script-with-java-on-openhab-5-0-1-0-6-0-0-0/159853/19) without `.toString()`:
    
```java
return java.util.regex.Pattern.matches("A.*", input) ? "TRUE" : "FALSE";
```
