### PR TITLE
README: thingManager example

### DIFF
--- a/bundles/org.openhab.automation.java223/README.md
+++ b/bundles/org.openhab.automation.java223/README.md
@@ -582,11 +582,8 @@ public class RunAnotherRule {
 
 The thingManager is not a standard JSR223 variable, but the Java223 automation bundle can nonetheless inject it. It is also available in the base class `Java223Script`, as shown in this example.
 
-```java 
-import java.util.Map;
-import org.openhab.core.automation.RuleManager;
-
-public class DisableThing extends Java223Script {
+```java
+public class DisableThing extends helper.generated.Java223Script {
     public void main() {
         thingManager.setEnabled(_things.network_pingdevice_mything().getUID(), false);
     }


### PR DESCRIPTION
I cannot get this example working, as it is.

This works:
```java
public class DisableThing extends helper.generated.Java223Script {
    public void main() {
        thingManager.setEnabled(_things.network_pingdevice_mything().getUID(), false);
    }
}
```
If the `import` was necessary, then `import org.openhab.core.thing.ThingManager;` is correct and `import org.openhab.core.automation.ThingManager;` provides errors.

```java
import org.openhab.core.thing.ThingManager;

public class DisableThing extends helper.generated.Java223Script {
    public void main() {
        ThingManager thingManager;
        thingManager.setEnabled(_things.network_pingdevice_mything().getUID(), false);
    }
}
```
fails with
```
2025-10-03 10:37:32.456 [ERROR] [ipt.internal.ScriptEngineManagerImpl] - Error during evaluation of script '/etc/openhab/automation/jsr223/DisableThing.java': /DisableThing.java:6: error: variable thingManager might not have been initialized
        thingManager.setEnabled(_things.mqtt_topic_r9().getUID(), false);
        ^
```
Also
```java
import org.openhab.core.thing.ThingManager;
import org.openhab.automation.java223.common.InjectBinding;

public class DisableThing extends helper.generated.Java223Script {
    public void main() {
        @InjectBinding ThingManager thingManager;
        thingManager.setEnabled(_things.network_pingdevice_mything().getUID(), false);
    }
}
```
produces
```
2025-10-03 10:38:36.683 [ERROR] [ipt.internal.ScriptEngineManagerImpl] - Error during evaluation of script '/etc/openhab/automation/jsr223/DisableThing.java': /DisableThing.java:6: error: annotation interface not applicable to this kind of declaration
        @InjectBinding ThingManager thingManager;
        ^
```
This again works:
```java
import org.openhab.core.thing.ThingManager;
import org.openhab.automation.java223.common.InjectBinding;

public class DisableThing extends helper.generated.Java223Script {
    @InjectBinding ThingManager thingManager;
    public void main() {
        thingManager.setEnabled(_things.network_pingdevice_mything().getUID(), false);
    }
}
```
That said, I do not know what exactly this example wants to demonstrate, as there are many possibilites. 