### PR TITLE
ScriptWrappingStrategy: add more imports from the OH-JSR223 implicit preset

### DIFF
--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/ScriptWrappingStrategy.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/ScriptWrappingStrategy.java
@@ -43,6 +43,12 @@ public class ScriptWrappingStrategy implements ScriptInterceptorStrategy {
     private static final Pattern IMPORT_PATTERN = Pattern.compile("import\\s+[A-Za-z][A-Za-z0-9_$.]*;\\s*");
 
     private static final String BOILERPLATE_CODE_COMMON_IMPORT = """
+            import java.time.DayOfWeek;
+            import java.time.Duration;
+            import java.time.Month;
+            import java.time.ZoneId;
+            import java.time.ZonedDateTime;
+            import java.time.temporal.ChronoUnit;
             import org.openhab.core.library.items.*;
             import org.openhab.core.library.types.*;
             import static org.openhab.core.library.types.HSBType.*;


### PR DESCRIPTION
As spelled at https://github.com/openhab/openhab-docs/pull/2571 the type java.time.ZonedDateTime is available in transformations, is part of the implicit presets.  So this sitemap works
```
sitemap x label="X" {
  Text item=x label="A [GROOVY(|return ZonedDateTime.now();):%s]"
}
```
This sitemap does not work:
```
sitemap x label="X" {
  Text item=x label="B [JAVA(|return ZonedDateTime.now();):%s]"
}
```
```
2025-10-04 14:23:57.783 [WARN ] [ui.internal.items.ItemUIRegistryImpl] - Failed transforming the value '-' with pattern 'JAVA(|return ZonedDateTime.now();):-': /WrappedJavaScript.java:22: error: cannot find symbol
return ZonedDateTime.now();
       ^
  symbol:   variable ZonedDateTime
  location: class WrappedJavaScript
```
I have to put prefix `java.time.` before ZonedDateTime, unless the current patch is applied.

The other thing missing from ScriptWrappingStrategy, but part of the default preset, or rather part of the `lifecycle` preset, which like the `media` and `default` presets is implicitly preloaded, as described at https://github.com/openhab/openhab-docs/pull/2567 ⇔ https://deploy-preview-2567--openhab-docs-preview.netlify.app/docs/configuration/jsr223.html#lifecycle-preset-importpreset-not-required is the `lifecycleTracker` object. 

I think these imports should not be hard-coded in ScriptWrappingStrategy, but somehow implied, when `Java223ScriptEngineFactory.scopeValues()` is invoked.