### PR TITLE
Fix `org.openhab.core.library.unit.SIUnits.getInstance()`

### DIFF
--- a/bundles/org.openhab.automation.java223/bnd.bnd
+++ b/bundles/org.openhab.automation.java223/bnd.bnd
@@ -3,6 +3,7 @@ DynamicImport-Package: *
 Import-Package: \
 javax.measure,\
 javax.measure.quantity,\
+javax.measure.spi,\
 org.openhab.core.audio,\
 org.openhab.core.automation,\
 org.openhab.core.automation.util,\
@@ -27,4 +28,6 @@ org.openhab.core.transform,\
 org.openhab.core.transform.actions,\
 org.openhab.core.types,\
 org.openhab.core.voice,\
-com.google.gson
+com.google.gson,\
+tech.units.indriya,\
+tech.uom.lib.common.function

--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/codegeneration/InjectedCodeGenerator.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/codegeneration/InjectedCodeGenerator.java
@@ -116,11 +116,6 @@ public class InjectedCodeGenerator {
                 Package aPackage = clazz.getPackage();
                 String packageName = aPackage != null ? aPackage.getName() : null;
 
-                // TODO fix why can't we import org.openhab.core.library.unit ??
-                if ("org.openhab.core.library.unit".equals(packageName)) {
-                    return null;
-                }
-
                 if (packageName != null && !packageName.isEmpty()) {
                     return new ImportAndDeclaration("import " + canonicalName + ";", null);
                 } else {


### PR DESCRIPTION
With the current change
```java
import org.openhab.core.library.unit.SIUnits;
public class F {
    public Object main() {
        org.slf4j.LoggerFactory.getLogger("J").error(SIUnits.getInstance().toString());
        return null;
    }
}
```
prints
> 2025-10-08 16:49:26.145 [ERROR] [J                                   ] - org.openhab.core.library.unit.SIUnits@314d74a3

Without the change, the output is
```
2025-10-08 16:52:25.254 [ERROR] [ipt.internal.ScriptEngineManagerImpl] - Error during evaluation of script '/etc/openhab/automation/jsr223/f.java': /F.java:4: error: cannot access tech.units.indriya.AbstractSystemOfUnits
        org.slf4j.LoggerFactory.getLogger("J").error(SIUnits.getInstance().toString()); 
                                                             ^
  class file for tech.units.indriya.AbstractSystemOfUnits not found
2025-10-08 16:52:25.255 [WARN ] [ort.loader.AbstractScriptFileWatcher] - Script loading error, ignoring file '/etc/openhab/automation/jsr223/f.java'
```
I do not understand what is going on, and I do not get what is the actual problem solved by the early return in `InjectedCodeGenerator.generateImportAndDeclaration()`.

Besides, what is the point to include in helper/henerated/Java223Script.java:
```
import static org.openhab.core.library.types.OnOffType.ON;
import org.openhab.core.library.types.StringType;
import java.time.ZonedDateTime;
import org.openhab.core.library.unit.ImperialUnits;
```
if Java223Script does not use `ZonedDateTime`, `StringType`, `ImperialUnits` and `ON`?