### PR TITLE
typos

### DIFF
--- a/bundles/org.openhab.automation.java223/README.md
+++ b/bundles/org.openhab.automation.java223/README.md
@@ -78,14 +78,14 @@ The variable name is used to find the correct value to inject, so take care of y
 
 You can control the injection further (i.e. overriding default behavior, or directly injecting something from a preset) with the @InjectBinding annotation. See [example](#injectbinding).
 
-| InjectBinding parameter | Description                                                                                                                                                                                                                                                                                                                           |
-|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| enable                  | Prevent injection. Useful if you want to do it yourself.                                                                                                                                                                                                                                                                              |
-| named                   | Use this to specify the key used to get the value. If not specified, the field name will be use, or the type definition for libraries. You can also use a special 'path traversal' syntaxic sugar for getting field of field. Example 'event.itemName' will get the event object, and use java reflection to get its field 'itemName' |
-| preset                  | Use this field to inject value from a specific preset.                                                                                                                                                                                                                                                                                |
-| mandatory               | If set to true (which is the default), the injection will fail if the variable is not found.                                                                                                                                                                                                                                          |
-| defaultValue            | The default value to inject if the variable is not found. If not set, the injection will fail if the variable is not found.                                                                                                                                                                                                           |
-| recursive               | For library only. If set to true (default), the library injected will be parsed and its field also injected.                                                                                                                                                                                                                          |
+| InjectBinding parameter | Description                                                                                                                                                                                                                                                                                                                            |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| enable                  | Prevent injection. Useful if you want to do it yourself.                                                                                                                                                                                                                                                                               |
+| named                   | Use this to specify the key used to get the value. If not specified, the field name will be used, or the type definition for libraries. You can also use a special 'path traversal' syntaxic sugar for getting field of field. Example 'event.itemName' will get the event object, and use java reflection to get its field 'itemName' |
+| preset                  | Use this field to inject value from a specific preset.                                                                                                                                                                                                                                                                                 |
+| mandatory               | If set to true (which is the default), the injection will fail if the variable is not found.                                                                                                                                                                                                                                           |
+| defaultValue            | The default value to inject if the variable is not found. If not set, the injection will fail if the variable is not found.                                                                                                                                                                                                            |
+| recursive               | For library only. If set to true (default), the library injected will be parsed and its field also injected.                                                                                                                                                                                                                           |
 
 <a id="rules"></a>
 
@@ -219,11 +219,11 @@ Here, `ItemStateChange` is available in the helper-lib.jar, alongside other stro
 
 Here are all functionalities of the helper-lib:
 
-- Many different `@Trigger` class. Check the `helper.rules.annotation` package for a list.
+- Many different `@Trigger` classes. Check the `helper.rules.annotation` package for a list.
 - You can add (multiple) `@Condition` to a Rule. It exposes a pre-condition for the rule to execute. Check the `helper.rules.annotation` package
 - `@Trigger`, `@Conditions`, `@Rule` have many parameters. Some parameters add functionality; others can overwrite default behavior (for example, using the method name for the label of a rule).
 - Pre-made event objects that you can use as a parameter in a rule are defined in the package `helper.rules.eventinfo`. You can define your own if some are missing (do not hesitate to make a Pull Request)
-- If you want all the triggering event input parameters in a map for a rule, you can use the parameter `Map<String, ?> bindings` in the rule method.`.
+- If you want all the triggering event input parameters in a map for a rule, you can use the parameter `Map<String, ?> bindings` in the rule method.
 - You can set the `@Rule` annotation on a method, but also on many types of field containing code to execute, such as Function, Runnable... Take a look at the class `Java223Rule` for an exhaustive list of what is supported. You can even switch the value of the field containing code at runtime, thus making the code your rule execute even more dynamic.
 
 <a id="sharedcache"></a>
@@ -596,7 +596,7 @@ import org.openhab.core.library.types.OnOffType;
 
 public class ConstructorInjectionExample {
     // The injection WON'T happen here because the variable name is not the name of an available openHAB input.
-    // By using @InjectBinding(enabled=false) you can prevent the Java223 bundle to even try to inject an openHAB value.
+    // By using @InjectBinding(enable=false) you can prevent the Java223 bundle to even try to inject an openHAB value.
     ItemRegistry myItemRegistry;
 
     public ConstructorInjectionExample(ItemRegistry itemRegistry) { // <-- the injection will happen here, 'itemRegistry' is a valid openHAB input name

--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/common/BindingInjector.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/common/BindingInjector.java
@@ -281,7 +281,7 @@ public class BindingInjector {
      * @param classLoader the source script class loader
      * @param executable Method or constructor
      * @param bindings The map used to search the appropriate value to inject
-     * @param libAlreadyInstanciated To avoid looping the instantiation of libraries
+     * @param libAlreadyInstantiated To avoid looping the instantiation of libraries
      * @return An array of parameter values that fits the executable
      * @throws InstantiationException If instantiation of the parameter doesn't work
      * @throws IllegalAccessException If reflexion fails
@@ -289,15 +289,15 @@ public class BindingInjector {
      * @throws InvocationTargetException If reflexion fails
      */
     public static Object @Nullable [] getParameterValuesFor(ClassLoader classLoader, Executable executable,
-            Map<String, Object> bindings, @Nullable Map<Class<?>, Object> libAlreadyInstanciated)
+            Map<String, Object> bindings, @Nullable Map<Class<?>, Object> libAlreadyInstantiated)
             throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         Parameter[] parameters = executable.getParameters();
         Object @Nullable [] parameterValues = new Object[parameters.length];
-        Map<Class<?>, Object> libAlreadyInstanciatedLocal = libAlreadyInstanciated != null ? libAlreadyInstanciated
+        Map<Class<?>, Object> libAlreadyInstantiatedLocal = libAlreadyInstantiated != null ? libAlreadyInstantiated
                 : new HashMap<>();
         for (int i = 0; i < parameters.length; i++) {
             parameterValues[i] = extractBindingValueForElement(classLoader, bindings, parameters[i],
-                    libAlreadyInstanciatedLocal);
+                    libAlreadyInstantiatedLocal);
         }
         return parameterValues;
     }

--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/jarloader/JarFileManager.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/jarloader/JarFileManager.java
@@ -156,7 +156,7 @@ public class JarFileManager<M extends JavaFileManager> extends ForwardingJavaFil
             try {
                 this.md5Digest = MessageDigest.getInstance("MD5");
             } catch (NoSuchAlgorithmException e) {
-                throw new Java223Exception("Cannot instanciate md5 digest. Should not happen");
+                throw new Java223Exception("Cannot instantiate md5 digest. Should not happen");
             }
         }
 

--- a/bundles/org.openhab.automation.java223/src/main/resources/generated/Items.ftl
+++ b/bundles/org.openhab.automation.java223/src/main/resources/generated/Items.ftl
@@ -37,6 +37,6 @@ public class Items {
         if (itemRegistry != null) {
             return itemRegistry.get(itemId);
         }
-        throw new Java223Exception("Items class not properly initialized. Use automatic instanciation by injection.");
+        throw new Java223Exception("Items class not properly initialized. Use automatic instantiation by injection.");
     }
 }

--- a/bundles/org.openhab.automation.java223/src/main/resources/generated/Java223Script.ftl
+++ b/bundles/org.openhab.automation.java223/src/main/resources/generated/Java223Script.ftl
@@ -41,7 +41,6 @@ ${fieldsDeclaration}
     protected @InjectBinding ScriptExtensionManagerWrapper scriptExtension;
     protected @InjectBinding ScriptExtensionManagerWrapper se;
 
-    // from ruleSupport preset
     protected @InjectBinding(preset = "RuleSupport") ScriptedAutomationManager automationManager;
     protected @InjectBinding(preset = "cache") ValueCache sharedCache;
     protected @InjectBinding(preset = "cache") ValueCache privateCache;

--- a/bundles/org.openhab.automation.java223/src/main/resources/generated/Things.ftl
+++ b/bundles/org.openhab.automation.java223/src/main/resources/generated/Things.ftl
@@ -34,7 +34,7 @@ public class Things {
         if (things != null) {
             return things.get(new ThingUID(stringUID));
         } else {
-            throw new Java223Exception("Things class not properly initialized. Use automatic instanciation by injection");
+            throw new Java223Exception("Things class not properly initialized. Use automatic instantiation by injection");
         }
     }
 


### PR DESCRIPTION
In Java223Script.ftl had to be spelled “RuleSupport” instead of “ruleSupport”.  It applies only to the next line, where the preset is explicitly spelled. For the cache preset, there is no such preceeding comment.
