### PR TITLE
eventinfo.ItemState(Chang,Updat)e - note about OH 5.0 changes

### DIFF
--- a/bundles/org.openhab.automation.java223/src/helper/java/helper/rules/eventinfo/ItemStateChange.java
+++ b/bundles/org.openhab.automation.java223/src/helper/java/helper/rules/eventinfo/ItemStateChange.java
@@ -35,10 +35,10 @@ public class ItemStateChange extends EventInfo {
     @InjectBinding()
     protected @NonNullByDefault({}) State newState;
 
-    @InjectBinding(mandatory = false)
+    @InjectBinding(mandatory = false) // available since openHAB 5.0
     protected @Nullable ZonedDateTime lastStateChange;
 
-    @InjectBinding(mandatory = false)
+    @InjectBinding(mandatory = false) // available since openHAB 5.0
     protected @Nullable ZonedDateTime lastStateUpdate;
 
     public String getItemName() {

--- a/bundles/org.openhab.automation.java223/src/helper/java/helper/rules/eventinfo/ItemStateUpdate.java
+++ b/bundles/org.openhab.automation.java223/src/helper/java/helper/rules/eventinfo/ItemStateUpdate.java
@@ -32,7 +32,7 @@ public class ItemStateUpdate extends EventInfo {
     @InjectBinding(named = "event.itemState")
     protected @NonNullByDefault({}) State state;
 
-    @InjectBinding(mandatory = false)
+    @InjectBinding(mandatory = false) // available since openHAB 5.0
     protected @Nullable ZonedDateTime lastStateUpdate;
 
     public String getItemName() {


### PR DESCRIPTION
Is the purpose of `mandatory=false` to make the Java233 bundle usable also under OpenHAB 4.3?

I have added to https://github.com/openhab/openhab-docs/pull/2582/files that these inputs appear since OH 5.0.