### PR TITLE
Remove metadataRegistry

### DIFF
--- a/bundles/org.openhab.automation.java223/README.md
+++ b/bundles/org.openhab.automation.java223/README.md
@@ -97,7 +97,6 @@ The Java223 bundle also provides some additional injections that are not availab
 |------------------|-----------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
 | ruleManager      | [`org.openhab.core.automation.RuleManager`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/rulemanager) | Run or disable/enable other rules |
 | thingManager     | [`org.openhab.core.thing.ThingManager`](https://www.openhab.org/javadoc/latest/org/openhab/core/thing/thingmanager)         | Enable/Disable thing              |
-| metadataRegistry | [`org.openhab.core.items.MetadataRegistry`](https://www.openhab.org/javadoc/latest/org/openhab/core/items/metadataregistry) | Manage metadata                   |
 
 
 ## Defining Rules
@@ -689,31 +688,6 @@ public class DisableThing extends helper.generated.Java223Script {
     }
 }
 ```
-
-
-## Use metadata
-
-The metadataRegistry is not a standard JSR223 variable, but the Java223 automation bundle can nonetheless inject it. This script overwrites Google Assistant metadata every time it is executed (so, at each openHAB startup), effectively keeping this file as some kind of external 'database' where you can store all your metadata.
-
-```java 
-public class MetadataDatabase {
-
-    protected MetadataRegistry metadataRegistry; // <-- auto injection here
-
-    public void main() {
-        create("ga", Items.lock, "Lock", Map.of("name", "Front door"));
-        create("ga", Items.room_light, "Light", Map.of("name", "Master bedroom light"));
-    }
-    
-    private void create(String namespace, String itemName, String value, Map<String, Object> configuration) {
-        MetadataKey metadataKey = new MetadataKey(namespace, itemName);
-        metadataRegistry.remove(metadataKey);
-        metadataRegistry.add(new Metadata(metadataKey, value, configuration));
-    }
-}
-```
-
-Tip: The metadataRegistry is already declared as a field in the Java223Script helper class that you can inherit.
 
 
 <a id="injectbinding"></a>

--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/common/Java223Constants.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/common/Java223Constants.java
@@ -28,7 +28,6 @@ public class Java223Constants {
 
     public static final String JAVA_FILE_TYPE = "java";
     public static final String JAR_FILE_TYPE = "jar";
-    public static final String METADATA_REGISTRY = "metadataRegistry";
     public static final String RULE_MANAGER = "ruleManager";
     public static final String THING_MANAGER = "thingManager";
 

--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223ScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223ScriptEngineFactory.java
@@ -49,7 +49,6 @@ import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventSubscriber;
 import org.openhab.core.items.ItemRegistry;
-import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.items.events.ItemAddedEvent;
 import org.openhab.core.items.events.ItemRemovedEvent;
 import org.openhab.core.service.WatchService;
@@ -116,8 +115,7 @@ public class Java223ScriptEngineFactory extends JavaScriptEngineFactory
             @Reference(target = WatchService.CONFIG_WATCHER_FILTER) WatchService watchService,
             @Reference ItemRegistry itemRegistry, @Reference ThingRegistry thingRegistry,
             @Reference Java223DependencyTracker dependencyTracker, @Reference RuleManager ruleManager,
-            @Reference ThingManager thingManager, @Reference MetadataRegistry metadataRegistry,
-            @Reference ScriptExtensionAccessor scriptExtensionAccessor) {
+            @Reference ThingManager thingManager, @Reference ScriptExtensionAccessor scriptExtensionAccessor) {
 
         try {
             Files.createDirectories(LIB_DIR);
@@ -143,7 +141,7 @@ public class Java223ScriptEngineFactory extends JavaScriptEngineFactory
         InjectedCodeGenerator injectedCodeGenerator = new InjectedCodeGenerator(scriptExtensionAccessor);
 
         osgiPackageResourceListingStrategy = this::listClassResources;
-        java223Strategy = new Java223Strategy(getAdditionalBindings(ruleManager, thingManager, metadataRegistry),
+        java223Strategy = new Java223Strategy(getAdditionalBindings(ruleManager, thingManager),
                 bundleContext.getBundle().adapt(BundleWiring.class).getClassLoader());
         java223Strategy.setAllowInstanceReuse(allowInstanceReuse);
         scriptWrappingStrategy = new ScriptWrappingStrategy(enableHelper, injectedCodeGenerator);
@@ -289,10 +287,8 @@ public class Java223ScriptEngineFactory extends JavaScriptEngineFactory
      *
      * @return Additional data to use when binding
      */
-    private Map<String, Object> getAdditionalBindings(RuleManager ruleManager, ThingManager thingManager,
-            MetadataRegistry metadataRegistry) {
+    private Map<String, Object> getAdditionalBindings(RuleManager ruleManager, ThingManager thingManager) {
         return Map.of(Java223Constants.RULE_MANAGER, ruleManager, //
-                Java223Constants.METADATA_REGISTRY, metadataRegistry, //
                 Java223Constants.THING_MANAGER, thingManager);
     }
 

--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/ScriptWrappingStrategy.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/strategy/ScriptWrappingStrategy.java
@@ -54,7 +54,6 @@ public class ScriptWrappingStrategy implements ScriptInterceptorStrategy {
             import org.openhab.core.automation.module.script.ScriptExtensionManagerWrapper;
             import org.openhab.core.automation.module.script.rulesupport.shared.ScriptedAutomationManager;
             import org.openhab.core.automation.module.script.rulesupport.shared.ValueCache;
-            import org.openhab.core.items.MetadataRegistry;
             import org.openhab.core.library.items.*;
             import org.openhab.core.thing.ThingManager;
             import org.slf4j.Logger;
@@ -79,7 +78,6 @@ public class ScriptWrappingStrategy implements ScriptInterceptorStrategy {
 
                 protected @InjectBinding RuleManager ruleManager;
                 protected @InjectBinding ThingManager thingManager;
-                protected @InjectBinding MetadataRegistry metadataRegistry;
             """;
 
     private static final String BOILERPLATE_CODE_HELPER_INJECTION = String.format("""

--- a/bundles/org.openhab.automation.java223/src/main/resources/generated/Java223Script.ftl
+++ b/bundles/org.openhab.automation.java223/src/main/resources/generated/Java223Script.ftl
@@ -9,7 +9,6 @@ import org.openhab.core.automation.RuleManager;
 import org.openhab.core.automation.module.script.ScriptExtensionManagerWrapper;
 import org.openhab.core.automation.module.script.rulesupport.shared.ScriptedAutomationManager;
 import org.openhab.core.automation.module.script.rulesupport.shared.ValueCache;
-import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.thing.ThingManager;
 import org.openhab.core.types.State;
 import org.slf4j.Logger;
@@ -26,7 +25,7 @@ ${imports}
  * Features:
  * - Standard JSR223 OpenHAB bindings already declared as fields for immediate access
  * - Auto execution of a parsing rule method (internalParseRules calling RuleAnnotationParser)
- * - Additional shortcut to useful services (automationManager, sharedCache, ruleManager, metadataRegistry)
+ * - Additional shortcut to useful services (automationManager, sharedCache, ruleManager)
  * - Include other generated helper classes (_items, _actions, _things)
  */
 public abstract class Java223Script {
@@ -52,7 +51,6 @@ ${fieldsDeclaration}
     // additional useful classes:
     protected @InjectBinding RuleManager ruleManager;
     protected @InjectBinding ThingManager thingManager;
-    protected @InjectBinding MetadataRegistry metadataRegistry;
 
     // generated classes
     protected @InjectBinding Items _items;


### PR DESCRIPTION
It is in the "provider" preset, so anyway available.

This leaves `medataRegistry` in codegeneration/InjectedCodeGeneratorTest.java.

`provider` preset : https://deploy-preview-2567--openhab-docs-preview.netlify.app/docs/configuration/jsr223.html#provider-preset .

I think it would be good to insert also an example for metadataRegistry usage in current openHAB-JSR223 languages (Groovy, JavaScript×2, JRule, Python×2) at https://deploy-preview-2567--openhab-docs-preview.netlify.app/docs/configuration/jsr223.html#provider-preset .  But I do not use these metadata and „Google Assistant” does not overwrite my metadata.

Openhab-JS has a `getService()` function - https://github.com/openhab/openhab-js/blob/main/src/osgi.js ⇔ https://github.com/openhab/openhab-addons/blob/main/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scope/OSGiScriptExtensionProvider.java - which can be used to get any service from openHAB, and uses for instance `osgi.getService('org.openhab.core.i18n.TimeZoneProvider')`.  Likewise in openhab-jruby:
```
$ git grep -in ruleMana 
.known_good_references:970:https://www.openhab.org/javadoc/latest/org/openhab/core/automation/RuleManager.html
lib/openhab/core/rules.rb:17:        # @return [org.openhab.core.automation.RuleManager] The openHAB rule manager/engine
lib/openhab/core/rules.rb:20:          @manager ||= OSGi.service("org.openhab.core.automation.RuleManager")
lib/openhab/rspec/karaf.rb:294:          wait_for_service("org.openhab.core.automation.RuleManager") do |re|
```
I think this would be useful not only in Java223, or in all other JSR223 add-ons, to be able to get arbitrary OSGi services, rather than do special utilization for `ruleManager` or `thingManager`.