### PR TITLE
README: clarifications for InjectBinding(mandatory=false)

### DIFF
--- a/bundles/org.openhab.automation.java223/README.md
+++ b/bundles/org.openhab.automation.java223/README.md
@@ -95,8 +95,10 @@ You can control the injection further (i.e. overriding default behavior, or dire
 | enable                  | If false, will prevent injection. Useful if you don't want an useless parsing of your class field.                                                                                                                                                                                                                                         |
 | named                   | Use this to specify the key used to get the value. If not specified, the field name will be used, or the type definition for libraries. You can also use a special 'path traversal' syntaxic sugar for getting field inside field. Example 'event.itemName' will get the event object, and use java reflection to get its field 'itemName' |
 | preset                  | Use this field to inject value from a specific preset.                                                                                                                                                                                                                                                                                     |
-| mandatory               | If set to true (which is the default when adding @InjectBinding) and the variable is not found, then the injection will fail, you will see an error log, and the script won't execute. You should use when you want to "fail fast".                                                                                                     |
+| mandatory               | If set to true (which is the default when adding @InjectBinding) and the variable is not found, then the injection will fail, you will see an error log, and the script won't execute. You should use when you want to "fail fast".                                                                                                        |
 | recursive               | For library only. If set to true (default), the library injected will be parsed and its field also injected.                                                                                                                                                                                                                               |
+
+Specifying `mandatory=false` is the same as skipping the `@InjectBinding` annotation.
 
 <a id="rules"></a>
 


### PR DESCRIPTION
Spell “Specifying `mandatory=false` is the same as skipping the `@InjectBinding` annotation.”

I think the option `mandatory=false` should be removed and instead described what is the difference between inserting `@InjectBinding` and skipping it.