### PR TITLE
README: put brackets after _items.my_bulb_item

### DIFF
--- a/bundles/org.openhab.automation.java223/README.md
+++ b/bundles/org.openhab.automation.java223/README.md
@@ -233,7 +233,7 @@ public class MyRule extends Java223Script {
     @Rule
     @ItemStateUpdateTrigger(itemName = Items.my_detector_item, state = EnumStrings.OnOffType.ON)
     public void myRule() {
-        _items.my_bulb_item.send(ON);
+        _items.my_bulb_item().send(ON);
     }
 }
 ```
@@ -259,7 +259,7 @@ public class MyRule extends Java223Script {
     @ItemStateUpdateTrigger(itemName = Items.my_detector_item, state = EnumStrings.OnOffType.ON)
     @ItemStateUpdateTrigger(itemName = Items.my_otherdetector_item, state = EnumStrings.OnOffType.ON)
     public void myRule(ItemStateUpdate inputs) { // <-- HERE, strongly typed parameter
-        _items.my_bulb_item.send(ON);
+        _items.my_bulb_item().send(ON);
         logger.info("Movement detected at " + inputs.getItemName()); // inputs.getItemName() gives the triggering detector name
     }
 }
@@ -547,7 +547,7 @@ public class MyRule extends Java223Script {
     @Rule
     @ItemStateUpdateTrigger(itemName = Items.my_detector_item, state = EnumStrings.OnOffType.ON)
     public void myRule() {
-        _items.my_bulb_item.send(OnOffType.ON);
+        _items.my_bulb_item().send(OnOffType.ON);
     }
 }
 ```


### PR DESCRIPTION
For me in
```java
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;
import helper.generated.EnumStrings;
import helper.generated.Items;
import helper.generated.Java223Script;
import helper.rules.annotations.ItemStateUpdateTrigger;
import helper.rules.annotations.Rule;
import helper.rules.eventinfo.ItemStateUpdate;

public class MyRule extends Java223Script {

    @Rule(name = "detecting.people", description = "Detecting people and light")
    @ItemStateUpdateTrigger(itemName = Items.r3, state = EnumStrings.OnOffType.ON)
    @ItemStateUpdateTrigger(itemName = Items.r9, state = EnumStrings.OnOffType.ON)
    public void myRule(ItemStateUpdate inputs) { // <-- HERE, strongly typed parameter                                                                                            
        Logger logger2 = LoggerFactory.getLogger(this.getClass());
        logger2.error("Movement detected at " + inputs.getItemName()); // inputs.getItemName() gives the triggerring detector name           
    }
}
```
`inputs.getItemName()` is null.

