### PR TITLE
MANIFEST.MF: remove Private-Package header

### DIFF
--- a/bundles/org.openhab.automation.java223/bnd.bnd
+++ b/bundles/org.openhab.automation.java223/bnd.bnd
@@ -31,3 +31,4 @@ org.openhab.core.voice,\
 com.google.gson,\
 tech.units.indriya,\
 tech.uom.lib.common.function
+-removeheaders: Private-Package


### PR DESCRIPTION
This removes from META-INF/MANIFEST.MF the header `Private-Package`.

According to https://docs.redhat.com/en/documentation/red_hat_fuse/7.3/html/deploying_into_apache_karaf/BuildBundle#ESBMavenOSGiPrivate the purpose of `Private-Package` header is to specify a list of packages to include in a bundle without exporting them.  However this does not work here, `Private-Package` included packages, which were anyway absent, like `OH-INF.addon`, `freemarker.ext.jython`, `freemarker.ext.rhino`.  The difference when building org.openhab.automation.java223-5.0.1.jar with or without this line is just the `Private-Package` header in MANIFEST.MF (and obviously the Bnd-LastModified header).

Closes https://github.com/dalgwen/openhab-addons/issues/38