### PR TITLE
Java223ScriptEngineFactory: remove itself as OSGi service

### DIFF
--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223ScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/Java223ScriptEngineFactory.java
@@ -76,8 +76,7 @@ import ch.obermuhlner.scriptengine.java.packagelisting.PackageResourceListingStr
  * @author Gwendal Roulleau - Initial contribution
  */
 @SuppressWarnings("unused")
-@Component(service = { ScriptEngineFactory.class, Java223ScriptEngineFactory.class,
-        EventSubscriber.class }, configurationPid = "automation.java223")
+@Component(service = { ScriptEngineFactory.class, EventSubscriber.class }, configurationPid = "automation.java223")
 @NonNullByDefault
 public class Java223ScriptEngineFactory extends JavaScriptEngineFactory
         implements ScriptEngineFactory, EventSubscriber, WatchService.WatchEventListener {


### PR DESCRIPTION
The OSGi service `org.openhab.automation.java223.internal.Java223ScriptEngineFactory` is not referenced from anywhere, so there is no need to create it.