### PR TITLE
ServiceGetter: utilize default service= for @Component

### DIFF
--- a/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/ServiceGetterImpl.java
+++ b/bundles/org.openhab.automation.java223/src/main/java/org/openhab/automation/java223/internal/ServiceGetterImpl.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Gwendal Roulleau - Initial contribution
  */
-@Component(service = ServiceGetter.class)
+@Component
 @NonNullByDefault
 @SuppressWarnings("unused")
 public class ServiceGetterImpl implements ServiceGetter {


### PR DESCRIPTION
In OSGi when a `@Component` does not specifiy `service = ` the services are implicilty set to the directly implemented interfaces.  Here this is ` implements ServiceGetter`.